### PR TITLE
Add cpu simulation for rays without a return

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ add_compile_options(-std=c++17)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   tf
+  visualization_msgs
 )
 
 find_package(gazebo REQUIRED)

--- a/include/livox_laser_simulation/livox_points_plugin.h
+++ b/include/livox_laser_simulation/livox_points_plugin.h
@@ -92,6 +92,8 @@ class LivoxPointsPlugin : public RayPlugin {
     std::shared_ptr<ros::NodeHandle> rosNode;
     ros::Publisher rosPointPub;
     ros::Publisher rosPointNoReturnPub;
+    ros::Publisher rosMarkersPub;
+
     std::shared_ptr<tf::TransformBroadcaster> tfBroadcaster;
 
     int64_t samplesStep = 0;

--- a/include/livox_laser_simulation/livox_points_plugin.h
+++ b/include/livox_laser_simulation/livox_points_plugin.h
@@ -82,6 +82,7 @@ class LivoxPointsPlugin : public RayPlugin {
     gazebo::physics::CollisionPtr laserCollision;
     physics::EntityPtr parentEntity;
     transport::PublisherPtr scanPub;
+    transport::PublisherPtr scanPubNoReturns;
     sdf::ElementPtr sdfPtr;
     msgs::LaserScanStamped laserMsg;
     transport::NodePtr node;
@@ -90,6 +91,7 @@ class LivoxPointsPlugin : public RayPlugin {
 
     std::shared_ptr<ros::NodeHandle> rosNode;
     ros::Publisher rosPointPub;
+    ros::Publisher rosPointNoReturnPub;
     std::shared_ptr<tf::TransformBroadcaster> tfBroadcaster;
 
     int64_t samplesStep = 0;

--- a/include/livox_laser_simulation/livox_points_plugin.h
+++ b/include/livox_laser_simulation/livox_points_plugin.h
@@ -91,7 +91,8 @@ class LivoxPointsPlugin : public RayPlugin {
 
     std::shared_ptr<ros::NodeHandle> rosNode;
     ros::Publisher rosPointPub;
-    ros::Publisher rosPointNoReturnPub;
+    ros::Publisher rosPointNonReturnPub;
+
     ros::Publisher rosMarkersPub;
 
     std::shared_ptr<tf::TransformBroadcaster> tfBroadcaster;

--- a/package.xml
+++ b/package.xml
@@ -53,6 +53,7 @@
   <build_export_depend>tf</build_export_depend>
   <exec_depend>tf</exec_depend>
   <depend>sensor_msgs</depend>
+  <depend>visualization_msgs</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/src/livox_ode_multiray_shape.cpp
+++ b/src/livox_ode_multiray_shape.cpp
@@ -161,7 +161,14 @@ void LivoxOdeMultiRayShape::UpdateCallback(void *_data, dGeomID _o1, dGeomID _o2
                     //      << " hit[" << hitCollision->GetScopedName() << "]"
                     //      << " pose[" << hitCollision->GetWorldPose() << "]"
                     //      << "\n";
-                    shape->SetLength(contact.depth);
+                    if (hitCollision->GetLaserRetro() < 0.0001)
+                    {
+                        shape->SetLength(0.0);
+                    }
+                    else
+                    {
+                        shape->SetLength(contact.depth);
+                    }
                     shape->SetRetro(hitCollision->GetLaserRetro());
                 }
             }

--- a/src/livox_ode_multiray_shape.cpp
+++ b/src/livox_ode_multiray_shape.cpp
@@ -164,12 +164,18 @@ void LivoxOdeMultiRayShape::UpdateCallback(void *_data, dGeomID _o1, dGeomID _o2
                     if (hitCollision->GetLaserRetro() < 0.0001)
                     {
                         shape->SetLength(0.0);
+                        shape->SetRetro(0.0);
+                    }
+                    else if(hitCollision->GetLaserRetro() <= 0.13371 && hitCollision->GetLaserRetro() >= 0.13369)
+                    {
+                        shape->SetLength(0.0);
+                        shape->SetRetro(0.1337);
                     }
                     else
                     {
                         shape->SetLength(contact.depth);
+                        shape->SetRetro(hitCollision->GetLaserRetro());
                     }
-                    shape->SetRetro(hitCollision->GetLaserRetro());
                 }
             }
         }

--- a/src/livox_ode_multiray_shape.cpp
+++ b/src/livox_ode_multiray_shape.cpp
@@ -166,9 +166,10 @@ void LivoxOdeMultiRayShape::UpdateCallback(void *_data, dGeomID _o1, dGeomID _o2
                         shape->SetLength(0.0);
                         shape->SetRetro(0.0);
                     }
+                    // Black car
                     else if(hitCollision->GetLaserRetro() <= 0.13371 && hitCollision->GetLaserRetro() >= 0.13369)
                     {
-                        shape->SetLength(0.0);
+                        shape->SetLength(contact.depth); // point is normally in center 0.0, but publish it at contact for visu
                         shape->SetRetro(0.1337);
                     }
                     else

--- a/src/livox_ode_multiray_shape.cpp
+++ b/src/livox_ode_multiray_shape.cpp
@@ -161,16 +161,11 @@ void LivoxOdeMultiRayShape::UpdateCallback(void *_data, dGeomID _o1, dGeomID _o2
                     //      << " hit[" << hitCollision->GetScopedName() << "]"
                     //      << " pose[" << hitCollision->GetWorldPose() << "]"
                     //      << "\n";
+                    // Non-return
                     if (hitCollision->GetLaserRetro() < 0.0001)
                     {
-                        shape->SetLength(0.0);
-                        shape->SetRetro(0.0);
-                    }
-                    // Black car
-                    else if(hitCollision->GetLaserRetro() <= 0.13371 && hitCollision->GetLaserRetro() >= 0.13369)
-                    {
                         shape->SetLength(contact.depth); // point is normally in center 0.0, but publish it at contact for visu
-                        shape->SetRetro(0.1337);
+                        shape->SetRetro(0.0);
                     }
                     else
                     {

--- a/src/livox_points_plugin.cpp
+++ b/src/livox_points_plugin.cpp
@@ -148,7 +148,6 @@ void LivoxPointsPlugin::OnNewLaserScans() {
                 range = 0.0;
             } else if (range <= RangeMin()) {
                 range = 0.0;
-                // this one should could be a point with no return -> publish it in second cloud with zenith / azimuth
             }
 
             auto retro = rayShape->GetRetro(idx);

--- a/src/livox_points_plugin.cpp
+++ b/src/livox_points_plugin.cpp
@@ -152,7 +152,7 @@ void LivoxPointsPlugin::OnNewLaserScans() {
             }
 
             auto retro = rayShape->GetRetro(idx);
-            if(retro >= 0.13369 && retro <= 0.13371)
+            if(retro == 0.0)
             {
                 range = 0.0;
                 countNoReturn++;
@@ -211,13 +211,10 @@ void LivoxPointsPlugin::OnNewLaserScans() {
         marker_msg.action = visualization_msgs::Marker::MODIFY;
         geometry_msgs::Point point_zero_msg;
         for (const auto [idx, rotateInfo] : points_pair) {
-            //auto range = rayShape->GetRange(idx);
             auto range = RangeMin() + rayShape->GetRange(idx);
             auto retro = rayShape->GetRetro(idx);
-            if (retro >= 0.13369 && retro <= 0.13371) // range == 0.0 &&
+            if (retro == 0.0)
             {
-                // set to fixed range to be able to show it in rViz
-                //range = 15.0;
                 *out_yaw = rotateInfo.azimuth;
                 *out_pitch = rotateInfo.zenith;
                 ignition::math::Quaterniond ray;

--- a/urdf/livox_mid360.xacro
+++ b/urdf/livox_mid360.xacro
@@ -7,6 +7,7 @@
   <xacro:property name="horizontal_fov" value="360"/>
   <xacro:property name="vertical_fov" value="180.0"/>
   <xacro:property name="ros_topic" value="scan"/>
+  <xacro:property name="ros_non_return_topic" value="non_return_rays"/>
   <xacro:property name="samples" value="20000"/>
   <xacro:property name="downsample" value="1"/>
 
@@ -21,7 +22,7 @@
     </inertial>
   </xacro:macro>
   <!-- CPU Based simulation -->
-  <xacro:macro name="livox_mid_gazebo_sensor" params="visualize:=False update_rate:=10 resolution:=0.002 noise_mean:=0.0 noise_stddev:=0.01 name:=livox ros_topic:=scan">
+  <xacro:macro name="livox_mid_gazebo_sensor" params="visualize:=False update_rate:=10 resolution:=0.002 noise_mean:=0.0 noise_stddev:=0.01 name:=livox ros_topic:=scan ros_non_return_topic:=non_return_rays">
     <gazebo reference="${name}">
       <sensor type="ray" name="laser_${name}">
         <pose>0 0 0 0 0 0</pose>
@@ -59,6 +60,7 @@
           <downsample>${downsample}</downsample>
           <csv_file_name>package://livox_laser_simulation/scan_mode/mid360.csv</csv_file_name>
           <ros_topic>${ros_topic}</ros_topic>
+          <ros_non_return_topic>${ros_non_return_topic}</ros_non_return_topic>
         </plugin>
       </sensor>
     </gazebo>
@@ -139,7 +141,7 @@
     </xacro:if>
     <xacro:unless value="${gpu_enabled}">
       <!-- CPU based simulation -->
-      <xacro:livox_mid_gazebo_sensor name="${name}" visualize="${visualize}" ros_topic="${ros_topic}"/>
+      <xacro:livox_mid_gazebo_sensor name="${name}" visualize="${visualize}" ros_topic="${ros_topic}" ros_non_return_topic="${ros_non_return_topic}"/>
     </xacro:unless>
   </xacro:macro>
     <xacro:Livox_Mid360 name="livox"/>


### PR DESCRIPTION
Simulate non-return rays, if the laser_retro value from the object is < 0.001. These rays are published as a pointcloud and also on a marker topic. 
Test together with PR in main repo.

Picture of simulated non-return rays with a black car:
![simulated_no_return_rays_markers](https://github.com/enwaytech/livox_laser_simulation/assets/54032815/5f634dbc-7739-49c4-a4be-95021959c264)

